### PR TITLE
Adding home directory permission

### DIFF
--- a/com.pinegrow.Pinegrow.yaml
+++ b/com.pinegrow.Pinegrow.yaml
@@ -9,6 +9,7 @@ finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --device=dri
+  - --filesystem=home
 modules:
 
   - name: pinegrow


### PR DESCRIPTION
Pinegrow mostly works with portals but some things like creating a new project from the home page fails (While creating a project by first opening an empty folder as a project works just fine).
Those workarounds may hinder usability, so for the time being I think it's a better choice to give Pinegrow access to the home directory.